### PR TITLE
Use PHPUnit\Framework\TestCase instead of PHPUnit_Framework_TestCase

### DIFF
--- a/test/GlipBotmanTest.php
+++ b/test/GlipBotmanTest.php
@@ -5,7 +5,7 @@ namespace Mpociot\BotMan\Tests\Drivers;
 use Mpociot\BotMan\Answer;
 use Mpociot\BotMan\BotMan;
 use Mpociot\BotMan\Message;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use Mpociot\BotMan\BotManFactory;
 use Mpociot\BotMan\DriverManager;
 use Mpociot\BotMan\Drivers\FakeDriver;
@@ -14,7 +14,7 @@ use Mpociot\BotMan\Drivers\ProxyDriver;
  * @covers \Mpociot\BotMan\Drivers\FakeDriver
  * @covers \Mpociot\BotMan\Drivers\ProxyDriver
  */
-class FakeDriverTest extends PHPUnit_Framework_TestCase
+class FakeDriverTest extends TestCase
 {
     /** @var BotMan */
     private $botman;


### PR DESCRIPTION
I use the `PHPUnit\Framework\TestCase` notation instead of `PHPUnit_Framework_TestCase` while extending our TestCase. This will help us migrate to PHPUnit 6, that [no longer support snake case class names](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-6.0.md#changed-1).